### PR TITLE
Add spatial transcriptomics tools to Preprocess section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ A knowledge collection of databases, software and papers related to computationa
 ## Preprocess
 
 - [Chemistry Development Kit](https://github.com/cdk/cdk) - A software of cheminformatics and Machine Learning.
+- [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance spatial transcriptomics deconvolution. Processes 1M spots in ~3 minutes.
 - [RDKit](https://github.com/rdkit/rdkit) - A software of cheminformatics and Machine Learning.
 - [Scanpy](https://scanpy.readthedocs.io/en/stable/) - scRNA analysis library in Python.
 - [Seurat](https://satijalab.org/seurat/) - scRNA analysis library in R.
-- [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance spatial transcriptomics deconvolution. Processes 1M spots in ~3 minutes.
 - [Squidpy](https://squidpy.readthedocs.io/) - Spatial single cell analysis library in Python.
 
 ## Machine Learning Tasks and Models


### PR DESCRIPTION
This PR adds spatial transcriptomics tools to the Preprocess section, complementing the existing scRNA tools (Scanpy, Seurat).

## Tools added:

1. **[FlashDeconv](https://github.com/cafferychen777/flashdeconv)** - High-performance spatial transcriptomics deconvolution. Processes 1M spots in ~3 minutes.

2. **[Squidpy](https://squidpy.readthedocs.io/)** - Spatial single cell analysis library in Python (from the scverse ecosystem).

These tools are commonly used alongside Scanpy and Seurat for spatial transcriptomics analysis.