### PR TITLE
Add ChatSpatial to Preprocess section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A knowledge collection of databases, software and papers related to computationa
 
 - [Chemistry Development Kit](https://github.com/cdk/cdk) - A software of cheminformatics and Machine Learning.
 - [RDKit](https://github.com/rdkit/rdkit) - A software of cheminformatics and Machine Learning.
-- [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods including SpaGCN, Cell2location, LIANA+, CellRank for spatial domains, deconvolution, cell communication, and trajectory analysis.
+- [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language.
 - [Scanpy](https://scanpy.readthedocs.io/en/stable/) - scRNA analysis library in Python.
 - [Seurat](https://satijalab.org/seurat/) - scRNA analysis library in R.
 


### PR DESCRIPTION
## Summary
- Add ChatSpatial to the Preprocess section alongside Scanpy and Seurat

## About ChatSpatial
[ChatSpatial](https://github.com/cafferychen777/ChatSpatial) is an MCP (Model Context Protocol) server enabling spatial transcriptomics analysis via natural language. It integrates 60+ methods including:

- **Spatial domains**: SpaGCN, STAGATE, GraphST
- **Deconvolution**: Cell2location, RCTD, DestVI, Tangram
- **Cell communication**: LIANA+, CellPhoneDB, CellChat
- **Trajectory analysis**: CellRank, Palantir, scVelo

Supports Visium, Xenium, MERFISH, Slide-seq and more.

- PyPI: https://pypi.org/project/chatspatial/
- Documentation: https://cafferychen777.github.io/ChatSpatial/