### PR TITLE
Add ClawBio — bioinformatics AI agent skill library

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated collection of databases, software, and papers related to computational
 - [GeneGPT](https://github.com/ncbi/GeneGPT) — LLM for biomedical information, integrated with various APIs.
 - [GenePT](https://github.com/yiqunchen/GenePT) — Foundation LLM for single-cell data.
 - [scPRINT](https://github.com/cantinilab/scPRINT) — Pretrained on 50M cells for scRNA-seq denoising & zero imputation.
+- [ClawBio](https://github.com/ClawBio/ClawBio) — Bioinformatics-native AI agent skill library with local-first pharmacogenomics, ancestry PCA, semantic similarity, nutrigenomics, and metagenomics skills.
 
 ### Foundation Models
 


### PR DESCRIPTION
## Summary

Add [ClawBio](https://github.com/ClawBio/ClawBio) to the **LLM for Biology** section.

ClawBio is a bioinformatics-native AI agent skill library built on [OpenClaw](https://github.com/open-claw/openclaw). It provides local-first, reproducible skills for:

- **Pharmacogenomics** (PharmGx) — DPWG/CPIC guideline lookup from personal VCFs
- **Ancestry PCA** — population-structure principal component analysis on 1000 Genomes + user data
- **Semantic Similarity** — PubMedBERT-powered disease-research coverage scoring across 13.1M PubMed abstracts and 175 GBD conditions
- **Nutrigenomics** — gene-nutrient interaction analysis (community-contributed)
- **Metagenomics** — 16S/shotgun microbiome profiling

Every skill ships with a reproducibility bundle (frozen environment, reference data checksums, deterministic outputs). The library was presented at the London Bioinformatics Meetup (Feb 2026) and is actively maintained.

- GitHub: https://github.com/ClawBio/ClawBio
- Docs / slides: https://clawbio.github.io/ClawBio