### PR TITLE
Add BGPT MCP to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Browse and search the resources via the [GitHub Pages UI](https://inoue0426.gith
 - [UniProt REST API](https://www.uniprot.org/help/api) — Programmatic access to protein sequence and functional annotation data.
 - [Ensembl REST API](https://rest.ensembl.org/) — API for genomic annotations, variants, genes, and comparative genomics.
 - [KEGG REST API](https://www.kegg.jp/kegg/rest/keggapi.html) — API for accessing KEGG pathways, compounds, genes, and reactions.
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies.
 - [ChEMBL Web Services](https://www.ebi.ac.uk/chembl/ws) — REST API for bioactive molecules, targets, and bioassays.
 - [Open Targets Platform API](https://platform.opentargets.org/api) — API for target–disease associations integrating genetics, genomics, and drug data.
 - [ClinicalTrials.gov API](https://clinicaltrials.gov/api/gui) — API for querying clinical trial metadata and results.

--- a/data/resources.csv
+++ b/data/resources.csv
@@ -1,4 +1,5 @@
 id,name,type,url,description,tags,tasks,modalities,organism,license,api,paper,updated
+bgpt_mcp,BGPT MCP,api,https://github.com/connerlambden/bgpt-mcp,"MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies.",api,,,,,True,,
 chembl_web_services,ChEMBL Web Services,api,https://www.ebi.ac.uk/chembl/ws,"REST API for bioactive molecules, targets, and bioassays.",api,,,,,True,,
 clinicaltrials_gov_api,ClinicalTrials.gov API,api,https://clinicaltrials.gov/api/gui,API for querying clinical trial metadata and results.,api,,,,,True,,
 ensembl_rest_api,Ensembl REST API,api,https://rest.ensembl.org/,"API for genomic annotations, variants, genes, and comparative genomics.",api,,,,,True,,

--- a/data/resources.json
+++ b/data/resources.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "bgpt_mcp",
+    "name": "BGPT MCP",
+    "type": "api",
+    "url": "https://github.com/connerlambden/bgpt-mcp",
+    "description": "MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies.",
+    "tags": [
+      "api"
+    ],
+    "tasks": [],
+    "modalities": [],
+    "organism": [],
+    "api": true
+  },
+  {
     "id": "chembl_web_services",
     "name": "ChEMBL Web Services",
     "type": "api",

--- a/data/resources.yml
+++ b/data/resources.yml
@@ -15,6 +15,17 @@
 #   paper       : DOI or URL to primary publication (optional)
 
 resources:
+  - id: bgpt_mcp
+    name: "BGPT MCP"
+    type: api
+    url: https://github.com/connerlambden/bgpt-mcp
+    description: "MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies."
+    tags: [api]
+    tasks: []
+    modalities: []
+    organism: []
+    api: true
+
   - id: chembl_web_services
     name: "ChEMBL Web Services"
     type: api

--- a/docs/data/resources.json
+++ b/docs/data/resources.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "bgpt_mcp",
+    "name": "BGPT MCP",
+    "type": "api",
+    "url": "https://github.com/connerlambden/bgpt-mcp",
+    "description": "MCP server and API for searching scientific papers and returning structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies.",
+    "tags": [
+      "api"
+    ],
+    "tasks": [],
+    "modalities": [],
+    "organism": [],
+    "api": true
+  },
+  {
     "id": "chembl_web_services",
     "name": "ChEMBL Web Services",
     "type": "api",


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — remote MCP server for searching scientific papers and returning structured experimental data (methods, results, quality scores, sample sizes) extracted from full-text studies.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers`
- npm: `npx bgpt-mcp`