### PR TITLE
feat: add TWZRD Agent Intel MCP to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Browse and search the resources via the [GitHub Pages UI](https://inoue0426.gith
 - [ClinicalTrials.gov API](https://clinicaltrials.gov/api/gui) — API for querying clinical trial metadata and results.
 
 ---
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP for AI drug discovery agents on Solana. Verify agent wallet identity before x402 micropayments to molecular databases and bioassay APIs. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Preprocessing Tools
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **API** section — it fits here as a trust/identity API for AI agents accessing computational biology and drug discovery data services.

**Use case:** AI drug discovery agents (e.g. agents querying ChEMBL, Open Targets, or ClinicalTrials.gov via x402 micropayments) can use TWZRD Agent Intel to verify wallet identity and score agents before granting access to paid molecular database APIs.

**Free MCP integration:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Tools:** `score_agent` (free), `preflight_check` (free), `get_trust_receipt` (paid via x402 micropayment)