### PR TITLE
Add Superhighway to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Browse and search the resources via the [GitHub Pages UI](https://inoue0426.gith
 - [ChEMBL Web Services](https://www.ebi.ac.uk/chembl/ws) — REST API for bioactive molecules, targets, and bioassays.
 - [Open Targets Platform API](https://platform.opentargets.org/api) — API for target–disease associations integrating genetics, genomics, and drug data.
 - [ClinicalTrials.gov API](https://clinicaltrials.gov/api/gui) — API for querying clinical trial metadata and results.
+- [Superhighway](https://superhighway.walls.sh) — Web search API (search, news, scrape, and research endpoints) usable for retrieving biomedical literature and clinical-trial information; provides an MCP server (`npx -y superhighway-mcp`).
 
 ---
 

--- a/data/resources.csv
+++ b/data/resources.csv
@@ -6,6 +6,7 @@ kegg_rest_api,KEGG REST API,api,https://www.kegg.jp/kegg/rest/keggapi.html,"API 
 ncbi_e_utilities,NCBI E-utilities,api,https://www.ncbi.nlm.nih.gov/books/NBK25501/,"Unified APIs for accessing NCBI databases (Gene, GEO, SRA, PubChem, etc).",api,,,,,True,,
 open_targets_platform_api,Open Targets Platform API,api,https://platform.opentargets.org/api,"API for target–disease associations integrating genetics, genomics, and drug data.",api,,,,,True,,
 pubmed_e_utilities_esearch_efetch,PubMed E-utilities (esearch/efetch),api,https://www.nlm.nih.gov/dataguide/edirect/esearch.html,APIs for searching and retrieving biomedical literature from PubMed.,api,,,,,True,,
+superhighway,Superhighway,api,https://superhighway.walls.sh,"Web search API (search, news, scrape, and research endpoints) usable for retrieving biomedical literature and clinical-trial information; provides an MCP server (`npx -y superhighway-mcp`).",api,,,,,True,,
 uniprot_rest_api,UniProt REST API,api,https://www.uniprot.org/help/api,Programmatic access to protein sequence and functional annotation data.,api,,,,,True,,
 1000_genomes_project,1000 Genomes Project,benchmark,https://www.internationalgenome.org/,"Reference panel of human genetic variation from 2,504 individuals across 26 populations.",benchmarks-and-datasets,,,,,False,,
 bace,BACE,benchmark,https://www.kaggle.com/datasets/gokturkkoch/bace,Binary classification and regression dataset for β-secretase 1 (BACE-1) inhibitor binding affinity.,benchmarks-and-datasets,,,,,False,,

--- a/data/resources.json
+++ b/data/resources.json
@@ -98,6 +98,20 @@
     "api": true
   },
   {
+    "id": "superhighway",
+    "name": "Superhighway",
+    "type": "api",
+    "url": "https://superhighway.walls.sh",
+    "description": "Web search API (search, news, scrape, and research endpoints) usable for retrieving biomedical literature and clinical-trial information; provides an MCP server (`npx -y superhighway-mcp`).",
+    "tags": [
+      "api"
+    ],
+    "tasks": [],
+    "modalities": [],
+    "organism": [],
+    "api": true
+  },
+  {
     "id": "uniprot_rest_api",
     "name": "UniProt REST API",
     "type": "api",

--- a/data/resources.yml
+++ b/data/resources.yml
@@ -92,6 +92,17 @@ resources:
     organism: []
     api: true
 
+  - id: superhighway
+    name: "Superhighway"
+    type: api
+    url: https://superhighway.walls.sh
+    description: "Web search API (search, news, scrape, and research endpoints) usable for retrieving biomedical literature and clinical-trial information; provides an MCP server (`npx -y superhighway-mcp`)."
+    tags: [api]
+    tasks: []
+    modalities: []
+    organism: []
+    api: true
+
   - id: uniprot_rest_api
     name: "UniProt REST API"
     type: api

--- a/docs/data/resources.json
+++ b/docs/data/resources.json
@@ -98,6 +98,20 @@
     "api": true
   },
   {
+    "id": "superhighway",
+    "name": "Superhighway",
+    "type": "api",
+    "url": "https://superhighway.walls.sh",
+    "description": "Web search API (search, news, scrape, and research endpoints) usable for retrieving biomedical literature and clinical-trial information; provides an MCP server (`npx -y superhighway-mcp`).",
+    "tags": [
+      "api"
+    ],
+    "tasks": [],
+    "modalities": [],
+    "organism": [],
+    "api": true
+  },
+  {
     "id": "uniprot_rest_api",
     "name": "UniProt REST API",
     "type": "api",


### PR DESCRIPTION
## Add Superhighway — web search API for AI agents

**[Superhighway](https://superhighway.walls.sh)** is a web search API built for AI agents: search, news, images, scrape, and research endpoints.

The [Biotech Pipeline Research Agent guide](https://superhighway.walls.sh/guides/biotech-research-agent) shows how to use it for biotech pipeline research and clinical trial competitive intelligence — querying ClinicalTrials.gov/STAT News/Fierce Pharma, classifying by drug modality (mAb, ADC, cell therapy, gene therapy, RNA therapy) and therapeutic area.

- **Auth**: `Authorization: Bearer YOUR_API_KEY` or pay-per-call with USDC via x402 (no signup required)
- **MCP server**: `npx -y superhighway-mcp`
- **Rate**: $0.002/call

Added under the **API** section. I ran `scripts/sync_resources_from_readme.py` and `scripts/build_resources.py` per the contribution workflow, so the regenerated `data/` and `docs/data/` artifacts are included in this PR.
