### PR TITLE
feat: add AI4Bio landscape database

### DIFF
--- a/docs/AI4BIO_LANDSCAPE.md
+++ b/docs/AI4BIO_LANDSCAPE.md
@@ -1,0 +1,60 @@
+# AI4Bio Landscape Database
+
+The landscape view treats the existing computational biology registry as a multidimensional database rather than a single hierarchical list.
+
+## Design goals
+
+- Keep the current curated resource records and generation pipeline intact.
+- Expose orthogonal facets so one resource can be explored by resource type, biological/ML task, data modality, organism, and domain tag.
+- Make the landscape useful without introducing a server or build-time dependency.
+- Keep the data model extensible for richer AI4Bio metadata over time.
+
+## Current facet model
+
+The landscape UI derives the following dimensions from `docs/data/resources.json`:
+
+| Dimension | Source field | Example values |
+|---|---|---|
+| Resource type | `type` | `database`, `benchmark`, `model`, `toolkit`, `api` |
+| Task | `tasks` | `drug-response-prediction`, `cell-type-annotation`, `molecular-generation` |
+| Modality | `modalities` | `transcriptomics`, `spatial-transcriptomics`, `protein-sequence` |
+| Organism | `organism` | `human`, `mouse`, `multi-species` |
+| Domain/tag | `tags` | `drug-discovery`, `single-cell`, `foundation-model` |
+
+These are deliberately treated as separate axes. A model can therefore be, for example, a `model` that performs `perturbation-prediction` on `single-cell-rna-seq` data for `human` and carry tags such as `drug-discovery` and `foundation-model`.
+
+## Recommended schema evolution
+
+The current schema is compatible with a richer landscape database. New fields should be added incrementally and only when they can be curated consistently.
+
+Suggested fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `entities` | array of strings | Biological entities such as `gene`, `protein`, `compound`, `cell`, `disease` |
+| `methods` | array of strings | Method families such as `transformer`, `gnn`, `diffusion`, `optimal-transport` |
+| `organizations` | array of strings | Primary organizations responsible for the resource |
+| `year` | integer | Initial public release/publication year |
+| `github` | string | Source repository when distinct from the canonical landing page |
+| `documentation` | string | Documentation URL |
+| `maintenance_status` | string | Curated status such as `active`, `maintenance`, `archived`, `unknown` |
+| `last_checked` | string | Date the metadata/link was last manually or automatically checked |
+
+Avoid adding dynamic popularity metrics such as GitHub stars directly to canonical records unless a reproducible refresh pipeline is introduced. Such values become stale quickly and should be stored as generated metadata rather than curated facts.
+
+## Canonical-source policy
+
+At present, `README.md` is the canonical curated list, with generated YAML/JSON/CSV artifacts. The landscape page intentionally consumes `docs/data/resources.json` without changing that policy.
+
+A future migration may make `data/resources.yml` the canonical source once all README-only categorization semantics can be represented explicitly in structured fields. That migration should be a separate change because it changes contribution workflow and source-of-truth semantics.
+
+## Landscape page
+
+Open `docs/landscape.html` through GitHub Pages. It provides:
+
+- full-text search across names, descriptions, tasks, modalities, organisms, and tags;
+- filters for type, task, modality, organism, and tag;
+- summary counts for resources and major dimensions;
+- frequency bars recalculated for the current filtered result set;
+- direct resource and paper links;
+- client-side rendering with no additional dependencies.

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
   <header>
     <h1>🧬 Awesome Computational Biology</h1>
     <p class="subtitle">A curated, searchable collection of databases, tools, models, and papers for computational biology.</p>
+    <p><a href="landscape.html">Explore the AI4Bio Landscape →</a></p>
   </header>
 
   <main>
@@ -54,6 +55,7 @@
   <footer>
     <p>
       View on <a href="https://github.com/inoue0426/awesome-computational-biology" target="_blank" rel="noopener noreferrer">GitHub</a>
+      · <a href="landscape.html">AI4Bio Landscape</a>
       · <a href="overview.html">Resource Overview</a>
       · Data from <code>data/resources.json</code>
     </p>

--- a/docs/landscape.css
+++ b/docs/landscape.css
@@ -1,0 +1,117 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --panel: #ffffff;
+  --text: #172033;
+  --muted: #667085;
+  --line: #dfe5ec;
+  --accent: #3156d3;
+  --accent-soft: #eef2ff;
+  --chip: #f0f4f8;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+a { color: var(--accent); }
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+  padding: 2.5rem clamp(1rem, 4vw, 4rem);
+  background: linear-gradient(135deg, #ffffff, #eef3ff);
+  border-bottom: 1px solid var(--line);
+}
+.hero h1 { margin: .45rem 0 .5rem; font-size: clamp(2rem, 5vw, 3.4rem); }
+.hero p { margin: 0; max-width: 760px; color: var(--muted); font-size: 1.05rem; }
+.back-link, .repo-link { font-weight: 700; text-decoration: none; }
+.repo-link { white-space: nowrap; }
+main { padding: 1.5rem clamp(1rem, 4vw, 4rem) 3rem; }
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.stats article {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
+}
+.stats strong { display: block; font-size: 1.8rem; }
+.stats span { color: var(--muted); }
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+.facets, .results-panel {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+}
+.facets { padding: 1rem; position: sticky; top: 1rem; }
+.search-block, .facet-block { margin-bottom: 1rem; }
+label { display: block; font-size: .86rem; font-weight: 700; margin-bottom: .35rem; }
+input, select, button {
+  width: 100%;
+  border: 1px solid #cfd7e3;
+  border-radius: 9px;
+  padding: .7rem .75rem;
+  background: #fff;
+  color: var(--text);
+  font: inherit;
+}
+button { margin-top: .55rem; cursor: pointer; font-weight: 700; background: var(--accent-soft); color: var(--accent); }
+.active-filters { display: flex; flex-wrap: wrap; align-items: center; gap: .35rem; margin-bottom: .9rem; font-size: .8rem; }
+.results-panel { padding: 1rem; min-width: 0; }
+.results-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; border-bottom: 1px solid var(--line); padding-bottom: .9rem; }
+.results-header h2, .facet-summary h2 { margin: 0; }
+.results-header p { color: var(--muted); margin: .25rem 0 0; }
+.sort-control { width: 170px; }
+.resource-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: .85rem; padding-top: 1rem; }
+.resource-card { border: 1px solid var(--line); border-radius: 13px; padding: 1rem; background: #fff; }
+.card-top { display: flex; justify-content: space-between; align-items: flex-start; gap: .7rem; }
+.card-top h3 { margin: 0; font-size: 1.02rem; line-height: 1.3; }
+.card-top a { text-decoration: none; }
+.description { color: #475467; font-size: .92rem; line-height: 1.55; min-height: 4.2em; }
+.metadata, .card-links { display: flex; flex-wrap: wrap; gap: .35rem; align-items: center; }
+.card-links { margin-top: .8rem; font-size: .78rem; }
+.card-links a { font-weight: 700; text-decoration: none; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; padding: .22rem .48rem; background: var(--chip); color: #475467; font-size: .72rem; line-height: 1.2; }
+.type-badge { background: #e9f8ef; color: #157347; white-space: nowrap; }
+.modality-badge { background: #fff4e5; color: #a15c00; }
+.tag-badge { background: #f3edff; color: #6941c6; }
+.api-badge { background: #e7f5ff; color: #146c94; }
+.license-badge { background: #f2f4f7; color: #344054; }
+.facet-summary { border-top: 1px solid var(--line); margin-top: 1.2rem; padding-top: 1rem; }
+.facet-summary h2 { font-size: 1rem; margin-bottom: .8rem; }
+.bar-group + .bar-group { margin-top: 1rem; }
+.bar-group h3 { font-size: .82rem; margin: 0 0 .5rem; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+.bar-row { margin-bottom: .5rem; }
+.bar-label { display: flex; justify-content: space-between; gap: .5rem; font-size: .75rem; margin-bottom: .2rem; }
+.bar-label span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bar-track { height: 5px; border-radius: 999px; background: #eef2f6; overflow: hidden; }
+.bar-fill { height: 100%; background: var(--accent); border-radius: inherit; }
+.empty-state { color: var(--muted); padding: 2rem; text-align: center; grid-column: 1 / -1; }
+footer { padding: 1.5rem clamp(1rem, 4vw, 4rem) 2.5rem; color: var(--muted); font-size: .86rem; }
+
+@media (max-width: 900px) {
+  .workspace { grid-template-columns: 1fr; }
+  .facets { position: static; }
+  .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 560px) {
+  .hero { flex-direction: column; }
+  .stats { grid-template-columns: 1fr 1fr; }
+  .resource-grid { grid-template-columns: 1fr; }
+  .results-header { align-items: stretch; flex-direction: column; }
+  .sort-control { width: 100%; }
+}

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI4Bio Landscape</title>
+  <meta name="description" content="Explore the Awesome Computational Biology resource registry as an AI4Bio landscape database." />
+  <link rel="stylesheet" href="landscape.css" />
+</head>
+<body>
+  <header class="hero">
+    <div>
+      <a class="back-link" href="index.html">← Resource browser</a>
+      <h1>🧬 AI4Bio Landscape</h1>
+      <p>Explore computational biology resources across tasks, modalities, organisms, resource types, and curated tags.</p>
+    </div>
+    <a class="repo-link" href="https://github.com/inoue0426/awesome-computational-biology" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+  </header>
+
+  <main>
+    <section class="stats" aria-label="Landscape summary">
+      <article><strong id="stat-resources">—</strong><span>resources</span></article>
+      <article><strong id="stat-tasks">—</strong><span>tasks</span></article>
+      <article><strong id="stat-modalities">—</strong><span>modalities</span></article>
+      <article><strong id="stat-tags">—</strong><span>tags</span></article>
+    </section>
+
+    <section class="workspace">
+      <aside class="facets" aria-label="Landscape filters">
+        <div class="search-block">
+          <label for="search">Search</label>
+          <input id="search" type="search" placeholder="Name, description, task, tag…" autocomplete="off" />
+          <button id="clear" type="button">Clear all</button>
+        </div>
+
+        <div id="active-filters" class="active-filters" aria-live="polite"></div>
+
+        <div class="facet-block">
+          <label for="type-filter">Resource type</label>
+          <select id="type-filter"><option value="">All types</option></select>
+        </div>
+        <div class="facet-block">
+          <label for="task-filter">Task</label>
+          <select id="task-filter"><option value="">All tasks</option></select>
+        </div>
+        <div class="facet-block">
+          <label for="modality-filter">Modality</label>
+          <select id="modality-filter"><option value="">All modalities</option></select>
+        </div>
+        <div class="facet-block">
+          <label for="organism-filter">Organism</label>
+          <select id="organism-filter"><option value="">All organisms</option></select>
+        </div>
+        <div class="facet-block">
+          <label for="tag-filter">Tag / domain</label>
+          <select id="tag-filter"><option value="">All tags</option></select>
+        </div>
+
+        <div class="facet-summary">
+          <h2>Top facets</h2>
+          <div id="facet-bars"></div>
+        </div>
+      </aside>
+
+      <section class="results-panel">
+        <div class="results-header">
+          <div>
+            <h2>Resources</h2>
+            <p id="result-count" aria-live="polite">Loading…</p>
+          </div>
+          <label class="sort-control">Sort
+            <select id="sort">
+              <option value="name">Name</option>
+              <option value="type">Type</option>
+            </select>
+          </label>
+        </div>
+        <div id="results" class="resource-grid"></div>
+      </section>
+    </section>
+  </main>
+
+  <footer>
+    <p>Powered by <code>docs/data/resources.json</code>. This view derives facets client-side and does not modify the canonical resource records.</p>
+  </footer>
+
+  <script src="landscape.js"></script>
+</body>
+</html>

--- a/docs/landscape.js
+++ b/docs/landscape.js
@@ -1,0 +1,236 @@
+const DATA_URL = "data/resources.json";
+
+const state = {
+  resources: [],
+  query: "",
+  type: "",
+  task: "",
+  modality: "",
+  organism: "",
+  tag: "",
+  sort: "name",
+};
+
+const els = {
+  search: document.querySelector("#search"),
+  clear: document.querySelector("#clear"),
+  type: document.querySelector("#type-filter"),
+  task: document.querySelector("#task-filter"),
+  modality: document.querySelector("#modality-filter"),
+  organism: document.querySelector("#organism-filter"),
+  tag: document.querySelector("#tag-filter"),
+  sort: document.querySelector("#sort"),
+  results: document.querySelector("#results"),
+  count: document.querySelector("#result-count"),
+  active: document.querySelector("#active-filters"),
+  bars: document.querySelector("#facet-bars"),
+  statResources: document.querySelector("#stat-resources"),
+  statTasks: document.querySelector("#stat-tasks"),
+  statModalities: document.querySelector("#stat-modalities"),
+  statTags: document.querySelector("#stat-tags"),
+};
+
+const arr = value => Array.isArray(value) ? value.filter(Boolean) : [];
+const norm = value => String(value || "").trim().toLowerCase();
+const uniqSorted = values => [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+
+function collect(field) {
+  return uniqSorted(state.resources.flatMap(resource => arr(resource[field])));
+}
+
+function populate(select, values) {
+  const first = select.firstElementChild;
+  select.replaceChildren(first);
+  for (const value of values) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  }
+}
+
+function searchableText(resource) {
+  return [
+    resource.name,
+    resource.description,
+    resource.type,
+    ...arr(resource.tasks),
+    ...arr(resource.modalities),
+    ...arr(resource.organism),
+    ...arr(resource.tags),
+  ].map(norm).join(" ");
+}
+
+function includesFacet(resource, field, selected) {
+  if (!selected) return true;
+  return arr(resource[field]).includes(selected);
+}
+
+function filteredResources() {
+  const query = norm(state.query);
+  return state.resources.filter(resource => {
+    if (query && !searchableText(resource).includes(query)) return false;
+    if (state.type && resource.type !== state.type) return false;
+    if (!includesFacet(resource, "tasks", state.task)) return false;
+    if (!includesFacet(resource, "modalities", state.modality)) return false;
+    if (!includesFacet(resource, "organism", state.organism)) return false;
+    if (!includesFacet(resource, "tags", state.tag)) return false;
+    return true;
+  }).sort((a, b) => {
+    if (state.sort === "type") {
+      return String(a.type).localeCompare(String(b.type)) || String(a.name).localeCompare(String(b.name));
+    }
+    return String(a.name).localeCompare(String(b.name));
+  });
+}
+
+function badge(label, className = "") {
+  const span = document.createElement("span");
+  span.className = `badge ${className}`.trim();
+  span.textContent = label;
+  return span;
+}
+
+function renderCard(resource) {
+  const card = document.createElement("article");
+  card.className = "resource-card";
+
+  const top = document.createElement("div");
+  top.className = "card-top";
+  const title = document.createElement("h3");
+  const link = document.createElement("a");
+  link.href = resource.url;
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.textContent = resource.name;
+  title.append(link);
+  top.append(title, badge(resource.type || "resource", "type-badge"));
+
+  const description = document.createElement("p");
+  description.className = "description";
+  description.textContent = resource.description || "No description available.";
+
+  const metadata = document.createElement("div");
+  metadata.className = "metadata";
+  for (const item of arr(resource.tasks).slice(0, 3)) metadata.append(badge(item));
+  for (const item of arr(resource.modalities).slice(0, 2)) metadata.append(badge(item, "modality-badge"));
+  for (const item of arr(resource.tags).slice(0, 3)) metadata.append(badge(item, "tag-badge"));
+
+  const links = document.createElement("div");
+  links.className = "card-links";
+  if (resource.paper) {
+    const paper = document.createElement("a");
+    paper.href = resource.paper;
+    paper.target = "_blank";
+    paper.rel = "noopener noreferrer";
+    paper.textContent = "Paper ↗";
+    links.append(paper);
+  }
+  if (resource.api) links.append(badge("API", "api-badge"));
+  if (resource.license) links.append(badge(resource.license, "license-badge"));
+
+  card.append(top, description, metadata, links);
+  return card;
+}
+
+function frequency(field, resources = state.resources) {
+  const counts = new Map();
+  for (const resource of resources) {
+    const values = field === "type" ? [resource.type] : arr(resource[field]);
+    for (const value of values.filter(Boolean)) counts.set(value, (counts.get(value) || 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+function renderFacetBars(resources) {
+  const groups = [
+    ["Tasks", "tasks"],
+    ["Modalities", "modalities"],
+    ["Types", "type"],
+  ];
+  els.bars.replaceChildren();
+  for (const [label, field] of groups) {
+    const section = document.createElement("section");
+    section.className = "bar-group";
+    const heading = document.createElement("h3");
+    heading.textContent = label;
+    section.append(heading);
+    const top = frequency(field, resources).slice(0, 5);
+    const max = Math.max(1, ...top.map(([, count]) => count));
+    for (const [name, count] of top) {
+      const row = document.createElement("div");
+      row.className = "bar-row";
+      row.innerHTML = `<div class="bar-label"><span></span><strong></strong></div><div class="bar-track"><div class="bar-fill"></div></div>`;
+      row.querySelector("span").textContent = name;
+      row.querySelector("strong").textContent = count;
+      row.querySelector(".bar-fill").style.width = `${Math.max(5, (count / max) * 100)}%`;
+      section.append(row);
+    }
+    els.bars.append(section);
+  }
+}
+
+function renderActiveFilters() {
+  const values = [state.type, state.task, state.modality, state.organism, state.tag].filter(Boolean);
+  els.active.replaceChildren();
+  if (!state.query && !values.length) return;
+  const label = document.createElement("span");
+  label.textContent = "Active:";
+  els.active.append(label);
+  if (state.query) els.active.append(badge(`search: ${state.query}`));
+  values.forEach(value => els.active.append(badge(value)));
+}
+
+function render() {
+  const resources = filteredResources();
+  els.count.textContent = `${resources.length.toLocaleString()} of ${state.resources.length.toLocaleString()} resources`;
+  els.results.replaceChildren(...resources.map(renderCard));
+  if (!resources.length) {
+    const empty = document.createElement("p");
+    empty.className = "empty-state";
+    empty.textContent = "No resources match the current filters.";
+    els.results.append(empty);
+  }
+  renderActiveFilters();
+  renderFacetBars(resources);
+}
+
+function bind() {
+  els.search.addEventListener("input", event => { state.query = event.target.value; render(); });
+  els.type.addEventListener("change", event => { state.type = event.target.value; render(); });
+  els.task.addEventListener("change", event => { state.task = event.target.value; render(); });
+  els.modality.addEventListener("change", event => { state.modality = event.target.value; render(); });
+  els.organism.addEventListener("change", event => { state.organism = event.target.value; render(); });
+  els.tag.addEventListener("change", event => { state.tag = event.target.value; render(); });
+  els.sort.addEventListener("change", event => { state.sort = event.target.value; render(); });
+  els.clear.addEventListener("click", () => {
+    Object.assign(state, {query: "", type: "", task: "", modality: "", organism: "", tag: ""});
+    els.search.value = "";
+    [els.type, els.task, els.modality, els.organism, els.tag].forEach(select => { select.value = ""; });
+    render();
+  });
+}
+
+async function init() {
+  try {
+    const response = await fetch(DATA_URL);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    state.resources = await response.json();
+    populate(els.type, uniqSorted(state.resources.map(resource => resource.type)));
+    populate(els.task, collect("tasks"));
+    populate(els.modality, collect("modalities"));
+    populate(els.organism, collect("organism"));
+    populate(els.tag, collect("tags"));
+    els.statResources.textContent = state.resources.length.toLocaleString();
+    els.statTasks.textContent = collect("tasks").length.toLocaleString();
+    els.statModalities.textContent = collect("modalities").length.toLocaleString();
+    els.statTags.textContent = collect("tags").length.toLocaleString();
+    bind();
+    render();
+  } catch (error) {
+    els.count.textContent = "Could not load landscape data.";
+    els.results.textContent = `Data load failed: ${error.message}`;
+  }
+}
+
+init();


### PR DESCRIPTION
## Summary

Adds an AI4Bio landscape view on top of the existing structured resource registry.

### What changed
- adds `docs/landscape.html` as a dedicated landscape explorer
- adds client-side faceted filtering across resource type, task, modality, organism, and tag/domain
- adds dynamic summary counts and facet-frequency bars
- adds responsive styling with no new runtime dependencies
- links the existing GitHub Pages browser to the new landscape view
- documents the landscape model and a conservative schema-evolution path in `docs/AI4BIO_LANDSCAPE.md`

### Design choice

This intentionally preserves the current canonical flow (`README.md` → generated YAML/JSON/CSV) and consumes `docs/data/resources.json` read-only. A future source-of-truth migration to structured data should be handled separately.

### Provenance

Implementation generated with assistance from OpenAI GPT-5.6 Sol. The GitHub connector used to create the commit does not expose custom Git author/committer fields, so GitHub attributes the commit to the connected account rather than a GPT identity.

### Validation

Static implementation was reviewed against the current schema and GitHub Pages file layout. No new dependencies or server-side components are introduced.