### PR TITLE
feat: add controlled vocabulary for AI4Bio enrichment

### DIFF
--- a/.github/workflows/ai4bio-schema-check.yml
+++ b/.github/workflows/ai4bio-schema-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - data/resources.yml
       - data/enrichment.yml
+      - data/vocabulary.yml
       - docs/data/resource.schema.json
       - scripts/validate_resources.py
       - scripts/build_resources_v2.py
@@ -13,6 +14,7 @@ on:
     paths:
       - data/resources.yml
       - data/enrichment.yml
+      - data/vocabulary.yml
       - docs/data/resource.schema.json
       - scripts/validate_resources.py
       - scripts/build_resources_v2.py

--- a/data/vocabulary.yml
+++ b/data/vocabulary.yml
@@ -1,0 +1,91 @@
+# Canonical vocabulary for new AI4Bio enrichment metadata.
+#
+# These values are enforced only for fields explicitly added through
+# data/enrichment.yml. README-derived legacy values remain backward compatible.
+# Canonical terms use lowercase kebab-case.
+
+version: 1
+
+controlled_fields:
+  entities:
+    - cell
+    - compound
+    - disease
+    - drug
+    - gene
+    - genome
+    - molecule
+    - organism
+    - pathway
+    - phenotype
+    - protein
+    - protein-complex
+    - regulatory-element
+    - tissue
+    - transcript
+    - variant
+
+  methods:
+    - autoencoder
+    - contrastive-learning
+    - convolutional-neural-network
+    - diffusion
+    - generative-model
+    - geometric-deep-learning
+    - graph-neural-network
+    - knowledge-graph
+    - language-model
+    - message-passing-neural-network
+    - multi-agent-system
+    - optimal-transport
+    - recurrent-neural-network
+    - reinforcement-learning
+    - retrieval-augmented-generation
+    - self-supervised-learning
+    - state-space-model
+    - supervised-learning
+    - transformer
+    - unsupervised-learning
+    - variational-autoencoder
+
+  modalities:
+    - cell-painting
+    - chemical-structure
+    - clinical
+    - dna-sequence
+    - electronic-health-record
+    - epigenomics
+    - genomics
+    - histopathology
+    - imaging
+    - knowledge-graph
+    - metabolomics
+    - molecular-structure
+    - multi-omics
+    - protein-sequence
+    - proteomics
+    - rna-sequence
+    - single-cell-rna-seq
+    - spatial-transcriptomics
+    - transcriptomics
+
+  tasks:
+    - batch-correction
+    - cell-type-annotation
+    - classification
+    - dimensionality-reduction
+    - docking
+    - drug-response-prediction
+    - drug-target-interaction
+    - foundation-model-pretraining
+    - gene-regulatory-network-inference
+    - imputation
+    - link-prediction
+    - molecular-generation
+    - perturbation-prediction
+    - protein-function-prediction
+    - regression
+    - representation-learning
+    - structure-prediction
+    - trajectory-inference
+    - virtual-screening

--- a/docs/data/SCHEMA_V2.md
+++ b/docs/data/SCHEMA_V2.md
@@ -9,7 +9,8 @@ The repository intentionally separates **membership/basic metadata** from **land
 1. `README.md` is the canonical curated resource list.
 2. `scripts/sync_resources_from_readme.py` derives `data/resources.yml` from README headings and bullets.
 3. `data/enrichment.yml` stores richer metadata keyed by stable resource `id`.
-4. `scripts/build_resources.py` merges base records and enrichment, validates them, and writes `data/resources.json`, `data/resources.csv`, and `docs/data/resources.json`.
+4. `data/vocabulary.yml` defines canonical terms for controlled enrichment dimensions.
+5. `scripts/build_resources.py` merges base records and enrichment, validates them, and writes `data/resources.json`, `data/resources.csv`, and `docs/data/resources.json`.
 
 This separation prevents hand-curated AI4Bio metadata from being erased by README synchronization.
 
@@ -38,6 +39,23 @@ These fields are required and may not be overridden by `data/enrichment.yml`:
 | `organizations` | string[] | Organizations maintaining or primarily responsible for the resource |
 
 These dimensions are deliberately orthogonal. Do not encode a task as a modality or a biological entity as a resource type.
+
+## Controlled vocabulary
+
+New values added through `data/enrichment.yml` for `entities`, `methods`, `modalities`, and `tasks` must use canonical terms from `data/vocabulary.yml`.
+
+Canonical terms use lowercase kebab-case, for example:
+
+```yaml
+entities: [cell, gene]
+methods: [transformer, self-supervised-learning]
+modalities: [single-cell-rna-seq, transcriptomics]
+tasks: [foundation-model-pretraining, cell-type-annotation]
+```
+
+This rule is intentionally applied only to enrichment metadata. Existing README-derived values remain valid for backward compatibility and can be migrated separately without blocking routine resource updates.
+
+When a required concept is missing, add a reusable canonical term to `data/vocabulary.yml` instead of inventing a one-off spelling in an enrichment record. `tags`, `organism`, and `organizations` remain free-form because their vocabularies are broader or context dependent.
 
 ## Provenance and lifecycle fields
 
@@ -90,9 +108,11 @@ Enrichment cannot override `id`, `name`, `type`, `url`, or `description`. A refe
 - ISO `YYYY-MM-DD` dates;
 - list uniqueness and non-empty values;
 - enrichment references and forbidden identity overrides;
+- controlled enrichment terms against `data/vocabulary.yml`;
+- vocabulary uniqueness and lowercase kebab-case normalization;
 - unknown field names.
 
-The machine-readable counterpart is `docs/data/resource.schema.json` (JSON Schema 2020-12).
+The machine-readable resource counterpart is `docs/data/resource.schema.json` (JSON Schema 2020-12). Controlled vocabulary enforcement is performed at the enrichment layer because legacy README-derived values intentionally remain backward compatible.
 
 ## Curation guidance
 

--- a/scripts/validate_resources.py
+++ b/scripts/validate_resources.py
@@ -19,12 +19,14 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASE_FILE = REPO_ROOT / "data" / "resources.yml"
 ENRICHMENT_FILE = REPO_ROOT / "data" / "enrichment.yml"
+VOCABULARY_FILE = REPO_ROOT / "data" / "vocabulary.yml"
 
 REQUIRED_FIELDS = ("id", "name", "type", "url", "description")
 LIST_FIELDS = (
     "tags", "tasks", "modalities", "organism", "entities", "methods",
     "organizations", "metadata_sources",
 )
+CONTROLLED_FIELDS = ("entities", "methods", "modalities", "tasks")
 ALLOWED_TYPES = {"api", "benchmark", "database", "model", "resource", "toolkit"}
 ALLOWED_MAINTENANCE = {"active", "maintenance", "archived", "unknown"}
 ALLOWED_ACCESS = {"open", "registration", "restricted", "commercial", "unknown"}
@@ -33,6 +35,7 @@ ALLOWED_FIELDS = set(REQUIRED_FIELDS) | set(LIST_FIELDS) | {
     "maintenance_status", "access", "last_checked",
 }
 ID_RE = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+VOCAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 URL_FIELDS = ("url", "paper", "github", "documentation")
 DATE_FIELDS = ("updated", "last_checked")
 
@@ -59,14 +62,76 @@ def validate_date(value: Any) -> bool:
         return False
 
 
+def load_vocabulary() -> tuple[dict[str, set[str]], list[str]]:
+    """Load and validate canonical terms used by new enrichment metadata."""
+    errors: list[str] = []
+    raw = load_yaml(VOCABULARY_FILE)
+    controlled = raw.get("controlled_fields")
+    if not isinstance(controlled, dict):
+        return {}, ["data/vocabulary.yml: 'controlled_fields' must be a mapping"]
+
+    unknown_fields = sorted(set(controlled) - set(CONTROLLED_FIELDS))
+    if unknown_fields:
+        errors.append(
+            "data/vocabulary.yml: unknown controlled fields: " + ", ".join(unknown_fields)
+        )
+
+    vocabulary: dict[str, set[str]] = {}
+    for field in CONTROLLED_FIELDS:
+        values = controlled.get(field)
+        if not isinstance(values, list) or not values:
+            errors.append(f"data/vocabulary.yml: '{field}' must be a non-empty list")
+            continue
+        if any(not isinstance(value, str) or not value.strip() for value in values):
+            errors.append(f"data/vocabulary.yml: '{field}' must contain non-empty strings")
+            continue
+        if len(values) != len(set(values)):
+            errors.append(f"data/vocabulary.yml: '{field}' contains duplicate terms")
+        invalid = sorted(value for value in values if not VOCAB_RE.fullmatch(value))
+        if invalid:
+            errors.append(
+                f"data/vocabulary.yml: '{field}' terms must use lowercase kebab-case: "
+                + ", ".join(invalid)
+            )
+        vocabulary[field] = set(values)
+
+    return vocabulary, errors
+
+
+def validate_enrichment_vocabulary(
+    resource_id: str,
+    fields: dict[str, Any],
+    vocabulary: dict[str, set[str]],
+) -> list[str]:
+    """Require canonical terms only for controlled fields added by enrichment."""
+    errors: list[str] = []
+    for field in CONTROLLED_FIELDS:
+        if field not in fields:
+            continue
+        values = fields[field]
+        if not isinstance(values, list):
+            continue
+        allowed = vocabulary.get(field, set())
+        for value in values:
+            if isinstance(value, str) and value not in allowed:
+                errors.append(
+                    f"enrichment [{resource_id}] '{field}' uses non-canonical term: {value!r}; "
+                    "add a canonical term to data/vocabulary.yml or use an existing one"
+                )
+    return errors
+
+
 def merge_resources() -> tuple[list[dict[str, Any]], list[str]]:
     errors: list[str] = []
     base = load_yaml(BASE_FILE).get("resources", [])
     overlay = load_yaml(ENRICHMENT_FILE).get("resources", {})
+    vocabulary, vocabulary_errors = load_vocabulary()
+    errors.extend(vocabulary_errors)
+
     if not isinstance(base, list):
-        return [], ["data/resources.yml: 'resources' must be a list"]
+        return [], errors + ["data/resources.yml: 'resources' must be a list"]
     if not isinstance(overlay, dict):
-        return [], ["data/enrichment.yml: 'resources' must be a mapping keyed by resource id"]
+        return [], errors + ["data/enrichment.yml: 'resources' must be a mapping keyed by resource id"]
 
     by_id: dict[str, dict[str, Any]] = {}
     for index, raw in enumerate(base, 1):
@@ -89,6 +154,7 @@ def merge_resources() -> tuple[list[dict[str, Any]], list[str]]:
         forbidden = set(REQUIRED_FIELDS) & set(fields)
         if forbidden:
             errors.append(f"enrichment [{resource_id}] cannot override identity fields: {', '.join(sorted(forbidden))}")
+        errors.extend(validate_enrichment_vocabulary(resource_id, fields, vocabulary))
         by_id[resource_id].update(fields)
 
     return list(by_id.values()), errors
@@ -146,7 +212,7 @@ def main() -> None:
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         sys.exit(1)
-    print(f"Validated {len(entries)} resources and enrichment metadata.")
+    print(f"Validated {len(entries)} resources, enrichment metadata, and controlled vocabulary.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a controlled vocabulary layer for new AI4Bio enrichment metadata so the landscape can scale without accumulating spelling and taxonomy drift.

### What changes
- adds `data/vocabulary.yml` with canonical terms for `entities`, `methods`, `modalities`, and `tasks`
- canonical terms use lowercase kebab-case
- validates controlled terms only when they are explicitly added through `data/enrichment.yml`
- preserves all existing README-derived values for backward compatibility
- validates the vocabulary itself for missing fields, duplicates, unknown fields, and invalid normalization
- updates the schema documentation with the vocabulary contract
- makes vocabulary-only changes trigger the AI4Bio schema CI workflow

### Design choice

This PR intentionally does **not** migrate existing README-derived values such as `Single Cell` or `Foundation Model`. Enforcing the vocabulary only at the enrichment layer prevents a large unrelated migration while ensuring all new curated metadata is normalized from this point forward.

### Next step

Once this vocabulary contract is stable, foundation model enrichment records can be added with provenance-backed metadata without introducing inconsistent terms.

### Provenance

Implementation prepared with assistance from OpenAI GPT-5.6 Sol.