### PR TITLE
feat: expose enriched metadata in AI4Bio landscape UI

### DIFF
--- a/.github/workflows/landscape-ui-check.yml
+++ b/.github/workflows/landscape-ui-check.yml
@@ -1,0 +1,30 @@
+name: Landscape UI Check
+
+on:
+  pull_request:
+    paths:
+      - docs/landscape.html
+      - docs/landscape.css
+      - docs/landscape.js
+      - .github/workflows/landscape-ui-check.yml
+  push:
+    branches: [main]
+    paths:
+      - docs/landscape.html
+      - docs/landscape.css
+      - docs/landscape.js
+      - .github/workflows/landscape-ui-check.yml
+
+permissions:
+  contents: read
+
+jobs:
+  ui-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Check landscape JavaScript syntax
+        run: node --check docs/landscape.js

--- a/docs/landscape.css
+++ b/docs/landscape.css
@@ -28,14 +28,14 @@ a { color: var(--accent); }
   border-bottom: 1px solid var(--line);
 }
 .hero h1 { margin: .45rem 0 .5rem; font-size: clamp(2rem, 5vw, 3.4rem); }
-.hero p { margin: 0; max-width: 760px; color: var(--muted); font-size: 1.05rem; }
+.hero p { margin: 0; max-width: 850px; color: var(--muted); font-size: 1.05rem; }
 .back-link, .repo-link { font-weight: 700; text-decoration: none; }
 .repo-link { white-space: nowrap; }
 main { padding: 1.5rem clamp(1rem, 4vw, 4rem) 3rem; }
 .stats {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: .8rem;
   margin-bottom: 1.5rem;
 }
 .stats article {
@@ -44,11 +44,11 @@ main { padding: 1.5rem clamp(1rem, 4vw, 4rem) 3rem; }
   border-radius: 14px;
   background: var(--panel);
 }
-.stats strong { display: block; font-size: 1.8rem; }
-.stats span { color: var(--muted); }
+.stats strong { display: block; font-size: 1.65rem; }
+.stats span { color: var(--muted); font-size: .84rem; }
 .workspace {
   display: grid;
-  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 1.25rem;
   align-items: start;
 }
@@ -57,7 +57,7 @@ main { padding: 1.5rem clamp(1rem, 4vw, 4rem) 3rem; }
   background: var(--panel);
   border-radius: 16px;
 }
-.facets { padding: 1rem; position: sticky; top: 1rem; }
+.facets { padding: 1rem; position: sticky; top: 1rem; max-height: calc(100vh - 2rem); overflow: auto; }
 .search-block, .facet-block { margin-bottom: 1rem; }
 label { display: block; font-size: .86rem; font-weight: 700; margin-bottom: .35rem; }
 input, select, button {
@@ -70,25 +70,51 @@ input, select, button {
   font: inherit;
 }
 button { margin-top: .55rem; cursor: pointer; font-weight: 700; background: var(--accent-soft); color: var(--accent); }
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  padding: .7rem .75rem;
+  margin: 0 0 1rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fafbff;
+  cursor: pointer;
+}
+.toggle-row input { width: auto; margin: 0; }
+.toggle-row span { font-size: .82rem; }
 .active-filters { display: flex; flex-wrap: wrap; align-items: center; gap: .35rem; margin-bottom: .9rem; font-size: .8rem; }
+.legacy-facets { border-top: 1px solid var(--line); padding-top: .85rem; }
+.legacy-facets summary { cursor: pointer; font-size: .86rem; font-weight: 800; margin-bottom: .9rem; }
 .results-panel { padding: 1rem; min-width: 0; }
 .results-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; border-bottom: 1px solid var(--line); padding-bottom: .9rem; }
 .results-header h2, .facet-summary h2 { margin: 0; }
 .results-header p { color: var(--muted); margin: .25rem 0 0; }
-.sort-control { width: 170px; }
+.sort-control { width: 190px; }
 .resource-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: .85rem; padding-top: 1rem; }
 .resource-card { border: 1px solid var(--line); border-radius: 13px; padding: 1rem; background: #fff; }
+.enriched-card { border-color: #c8d4ff; box-shadow: inset 3px 0 0 #6f88e8; }
 .card-top { display: flex; justify-content: space-between; align-items: flex-start; gap: .7rem; }
 .card-top h3 { margin: 0; font-size: 1.02rem; line-height: 1.3; }
 .card-top a { text-decoration: none; }
+.top-badges { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: .3rem; }
 .description { color: #475467; font-size: .92rem; line-height: 1.55; min-height: 4.2em; }
-.metadata, .card-links { display: flex; flex-wrap: wrap; gap: .35rem; align-items: center; }
+.metadata, .card-facts, .card-links { display: flex; flex-wrap: wrap; gap: .35rem; align-items: center; }
+.card-facts { margin-top: .7rem; padding-top: .7rem; border-top: 1px dashed var(--line); }
 .card-links { margin-top: .8rem; font-size: .78rem; }
 .card-links a { font-weight: 700; text-decoration: none; }
 .badge { display: inline-flex; align-items: center; border-radius: 999px; padding: .22rem .48rem; background: var(--chip); color: #475467; font-size: .72rem; line-height: 1.2; }
 .type-badge { background: #e9f8ef; color: #157347; white-space: nowrap; }
+.enriched-badge { background: #e8edff; color: #304fc4; }
+.entity-badge { background: #e8f8f5; color: #087a65; }
+.method-badge { background: #fff0f4; color: #a33a5b; }
 .modality-badge { background: #fff4e5; color: #a15c00; }
 .tag-badge { background: #f3edff; color: #6941c6; }
+.year-badge { background: #eef6ff; color: #175cd3; }
+.organization-badge { background: #f5f0ff; color: #6941c6; }
+.maintenance-badge { background: #ecfdf3; color: #067647; }
+.checked-badge { background: #f2f4f7; color: #475467; }
+.provenance-badge { background: #fff7d6; color: #865d00; }
 .api-badge { background: #e7f5ff; color: #146c94; }
 .license-badge { background: #f2f4f7; color: #344054; }
 .facet-summary { border-top: 1px solid var(--line); margin-top: 1.2rem; padding-top: 1rem; }
@@ -103,10 +129,12 @@ button { margin-top: .55rem; cursor: pointer; font-weight: 700; background: var(
 .empty-state { color: var(--muted); padding: 2rem; text-align: center; grid-column: 1 / -1; }
 footer { padding: 1.5rem clamp(1rem, 4vw, 4rem) 2.5rem; color: var(--muted); font-size: .86rem; }
 
+@media (max-width: 1180px) {
+  .stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
 @media (max-width: 900px) {
   .workspace { grid-template-columns: 1fr; }
-  .facets { position: static; }
-  .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .facets { position: static; max-height: none; }
 }
 @media (max-width: 560px) {
   .hero { flex-direction: column; }

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -12,7 +12,7 @@
     <div>
       <a class="back-link" href="index.html">← Resource browser</a>
       <h1>🧬 AI4Bio Landscape</h1>
-      <p>Explore computational biology resources across tasks, modalities, organisms, resource types, and curated tags.</p>
+      <p>Explore computational biology resources across tasks, modalities, biological entities, methods, organizations, years, and provenance-backed enrichment.</p>
     </div>
     <a class="repo-link" href="https://github.com/inoue0426/awesome-computational-biology" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
   </header>
@@ -20,41 +20,72 @@
   <main>
     <section class="stats" aria-label="Landscape summary">
       <article><strong id="stat-resources">—</strong><span>resources</span></article>
-      <article><strong id="stat-tasks">—</strong><span>tasks</span></article>
-      <article><strong id="stat-modalities">—</strong><span>modalities</span></article>
-      <article><strong id="stat-tags">—</strong><span>tags</span></article>
+      <article><strong id="stat-enriched">—</strong><span>enriched</span></article>
+      <article><strong id="stat-coverage">—</strong><span>enrichment coverage</span></article>
+      <article><strong id="stat-entities">—</strong><span>entities</span></article>
+      <article><strong id="stat-methods">—</strong><span>methods</span></article>
+      <article><strong id="stat-provenance">—</strong><span>enriched with provenance</span></article>
     </section>
 
     <section class="workspace">
       <aside class="facets" aria-label="Landscape filters">
         <div class="search-block">
           <label for="search">Search</label>
-          <input id="search" type="search" placeholder="Name, description, task, tag…" autocomplete="off" />
+          <input id="search" type="search" placeholder="Name, task, method, entity…" autocomplete="off" />
           <button id="clear" type="button">Clear all</button>
         </div>
+
+        <label class="toggle-row" for="enriched-only">
+          <input id="enriched-only" type="checkbox" />
+          <span>Show enriched resources only</span>
+        </label>
 
         <div id="active-filters" class="active-filters" aria-live="polite"></div>
 
         <div class="facet-block">
-          <label for="type-filter">Resource type</label>
-          <select id="type-filter"><option value="">All types</option></select>
+          <label for="entity-filter">Biological entity</label>
+          <select id="entity-filter"><option value="">All entities</option></select>
         </div>
         <div class="facet-block">
-          <label for="task-filter">Task</label>
-          <select id="task-filter"><option value="">All tasks</option></select>
+          <label for="method-filter">Method</label>
+          <select id="method-filter"><option value="">All methods</option></select>
         </div>
         <div class="facet-block">
-          <label for="modality-filter">Modality</label>
-          <select id="modality-filter"><option value="">All modalities</option></select>
+          <label for="year-filter">Year</label>
+          <select id="year-filter"><option value="">All years</option></select>
         </div>
         <div class="facet-block">
-          <label for="organism-filter">Organism</label>
-          <select id="organism-filter"><option value="">All organisms</option></select>
+          <label for="organization-filter">Organization</label>
+          <select id="organization-filter"><option value="">All organizations</option></select>
         </div>
         <div class="facet-block">
-          <label for="tag-filter">Tag / domain</label>
-          <select id="tag-filter"><option value="">All tags</option></select>
+          <label for="maintenance-filter">Maintenance status</label>
+          <select id="maintenance-filter"><option value="">All statuses</option></select>
         </div>
+
+        <details class="legacy-facets" open>
+          <summary>Core resource facets</summary>
+          <div class="facet-block">
+            <label for="type-filter">Resource type</label>
+            <select id="type-filter"><option value="">All types</option></select>
+          </div>
+          <div class="facet-block">
+            <label for="task-filter">Task</label>
+            <select id="task-filter"><option value="">All tasks</option></select>
+          </div>
+          <div class="facet-block">
+            <label for="modality-filter">Modality</label>
+            <select id="modality-filter"><option value="">All modalities</option></select>
+          </div>
+          <div class="facet-block">
+            <label for="organism-filter">Organism</label>
+            <select id="organism-filter"><option value="">All organisms</option></select>
+          </div>
+          <div class="facet-block">
+            <label for="tag-filter">Tag / domain</label>
+            <select id="tag-filter"><option value="">All tags</option></select>
+          </div>
+        </details>
 
         <div class="facet-summary">
           <h2>Top facets</h2>
@@ -72,6 +103,7 @@
             <select id="sort">
               <option value="name">Name</option>
               <option value="type">Type</option>
+              <option value="year">Newest enriched year</option>
             </select>
           </label>
         </div>
@@ -81,7 +113,7 @@
   </main>
 
   <footer>
-    <p>Powered by <code>docs/data/resources.json</code>. This view derives facets client-side and does not modify the canonical resource records.</p>
+    <p>Powered by <code>docs/data/resources.json</code>. Enriched fields are provenance-backed metadata merged from <code>data/enrichment.yml</code>; missing values are shown as unknown rather than inferred.</p>
   </footer>
 
   <script src="landscape.js"></script>

--- a/docs/landscape.js
+++ b/docs/landscape.js
@@ -8,6 +8,12 @@ const state = {
   modality: "",
   organism: "",
   tag: "",
+  entity: "",
+  method: "",
+  organization: "",
+  year: "",
+  maintenance: "",
+  enrichedOnly: false,
   sort: "name",
 };
 
@@ -19,34 +25,62 @@ const els = {
   modality: document.querySelector("#modality-filter"),
   organism: document.querySelector("#organism-filter"),
   tag: document.querySelector("#tag-filter"),
+  entity: document.querySelector("#entity-filter"),
+  method: document.querySelector("#method-filter"),
+  organization: document.querySelector("#organization-filter"),
+  year: document.querySelector("#year-filter"),
+  maintenance: document.querySelector("#maintenance-filter"),
+  enrichedOnly: document.querySelector("#enriched-only"),
   sort: document.querySelector("#sort"),
   results: document.querySelector("#results"),
   count: document.querySelector("#result-count"),
   active: document.querySelector("#active-filters"),
   bars: document.querySelector("#facet-bars"),
   statResources: document.querySelector("#stat-resources"),
-  statTasks: document.querySelector("#stat-tasks"),
-  statModalities: document.querySelector("#stat-modalities"),
-  statTags: document.querySelector("#stat-tags"),
+  statEnriched: document.querySelector("#stat-enriched"),
+  statCoverage: document.querySelector("#stat-coverage"),
+  statEntities: document.querySelector("#stat-entities"),
+  statMethods: document.querySelector("#stat-methods"),
+  statProvenance: document.querySelector("#stat-provenance"),
 };
 
 const arr = value => Array.isArray(value) ? value.filter(Boolean) : [];
 const norm = value => String(value || "").trim().toLowerCase();
-const uniqSorted = values => [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+const uniqSorted = values => [...new Set(values.filter(Boolean))].sort((a, b) => String(a).localeCompare(String(b)));
+const ENRICHMENT_FIELDS = [
+  "entities", "methods", "organizations", "github", "documentation", "year",
+  "access", "maintenance_status", "last_checked", "metadata_sources",
+];
 
 function collect(field) {
   return uniqSorted(state.resources.flatMap(resource => arr(resource[field])));
 }
 
-function populate(select, values) {
+function collectScalar(field) {
+  return uniqSorted(state.resources.map(resource => resource[field]));
+}
+
+function populate(select, values, formatter = value => value) {
+  if (!select) return;
   const first = select.firstElementChild;
   select.replaceChildren(first);
   for (const value of values) {
     const option = document.createElement("option");
     option.value = value;
-    option.textContent = value;
+    option.textContent = formatter(value);
     select.append(option);
   }
+}
+
+function isEnriched(resource) {
+  return ENRICHMENT_FIELDS.some(field => {
+    const value = resource[field];
+    return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null && value !== "";
+  });
+}
+
+function hasProvenance(resource) {
+  return arr(resource.metadata_sources).length > 0 || Boolean(resource.paper);
 }
 
 function searchableText(resource) {
@@ -54,10 +88,15 @@ function searchableText(resource) {
     resource.name,
     resource.description,
     resource.type,
+    resource.year,
+    resource.maintenance_status,
     ...arr(resource.tasks),
     ...arr(resource.modalities),
     ...arr(resource.organism),
     ...arr(resource.tags),
+    ...arr(resource.entities),
+    ...arr(resource.methods),
+    ...arr(resource.organizations),
   ].map(norm).join(" ");
 }
 
@@ -70,15 +109,24 @@ function filteredResources() {
   const query = norm(state.query);
   return state.resources.filter(resource => {
     if (query && !searchableText(resource).includes(query)) return false;
+    if (state.enrichedOnly && !isEnriched(resource)) return false;
     if (state.type && resource.type !== state.type) return false;
     if (!includesFacet(resource, "tasks", state.task)) return false;
     if (!includesFacet(resource, "modalities", state.modality)) return false;
     if (!includesFacet(resource, "organism", state.organism)) return false;
     if (!includesFacet(resource, "tags", state.tag)) return false;
+    if (!includesFacet(resource, "entities", state.entity)) return false;
+    if (!includesFacet(resource, "methods", state.method)) return false;
+    if (!includesFacet(resource, "organizations", state.organization)) return false;
+    if (state.year && String(resource.year || "") !== state.year) return false;
+    if (state.maintenance && resource.maintenance_status !== state.maintenance) return false;
     return true;
   }).sort((a, b) => {
     if (state.sort === "type") {
       return String(a.type).localeCompare(String(b.type)) || String(a.name).localeCompare(String(b.name));
+    }
+    if (state.sort === "year") {
+      return Number(b.year || 0) - Number(a.year || 0) || String(a.name).localeCompare(String(b.name));
     }
     return String(a.name).localeCompare(String(b.name));
   });
@@ -91,20 +139,30 @@ function badge(label, className = "") {
   return span;
 }
 
+function externalLink(label, href) {
+  const link = document.createElement("a");
+  link.href = href;
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.textContent = `${label} ↗`;
+  return link;
+}
+
 function renderCard(resource) {
   const card = document.createElement("article");
-  card.className = "resource-card";
+  card.className = `resource-card${isEnriched(resource) ? " enriched-card" : ""}`;
 
   const top = document.createElement("div");
   top.className = "card-top";
   const title = document.createElement("h3");
-  const link = document.createElement("a");
-  link.href = resource.url;
-  link.target = "_blank";
-  link.rel = "noopener noreferrer";
+  const link = externalLink(resource.name, resource.url);
   link.textContent = resource.name;
   title.append(link);
-  top.append(title, badge(resource.type || "resource", "type-badge"));
+  const topBadges = document.createElement("div");
+  topBadges.className = "top-badges";
+  topBadges.append(badge(resource.type || "resource", "type-badge"));
+  if (isEnriched(resource)) topBadges.append(badge("enriched", "enriched-badge"));
+  top.append(title, topBadges);
 
   const description = document.createElement("p");
   description.className = "description";
@@ -112,24 +170,33 @@ function renderCard(resource) {
 
   const metadata = document.createElement("div");
   metadata.className = "metadata";
+  for (const item of arr(resource.entities).slice(0, 3)) metadata.append(badge(item, "entity-badge"));
+  for (const item of arr(resource.methods).slice(0, 3)) metadata.append(badge(item, "method-badge"));
   for (const item of arr(resource.tasks).slice(0, 3)) metadata.append(badge(item));
   for (const item of arr(resource.modalities).slice(0, 2)) metadata.append(badge(item, "modality-badge"));
-  for (const item of arr(resource.tags).slice(0, 3)) metadata.append(badge(item, "tag-badge"));
+  if (!arr(resource.entities).length && !arr(resource.methods).length) {
+    for (const item of arr(resource.tags).slice(0, 3)) metadata.append(badge(item, "tag-badge"));
+  }
+
+  const facts = document.createElement("div");
+  facts.className = "card-facts";
+  if (resource.year) facts.append(badge(`Year ${resource.year}`, "year-badge"));
+  for (const item of arr(resource.organizations).slice(0, 2)) facts.append(badge(item, "organization-badge"));
+  if (resource.maintenance_status) facts.append(badge(resource.maintenance_status, "maintenance-badge"));
+  if (resource.last_checked) facts.append(badge(`checked ${resource.last_checked}`, "checked-badge"));
 
   const links = document.createElement("div");
   links.className = "card-links";
-  if (resource.paper) {
-    const paper = document.createElement("a");
-    paper.href = resource.paper;
-    paper.target = "_blank";
-    paper.rel = "noopener noreferrer";
-    paper.textContent = "Paper ↗";
-    links.append(paper);
-  }
+  if (resource.paper) links.append(externalLink("Paper", resource.paper));
+  if (resource.github && resource.github !== resource.url) links.append(externalLink("GitHub", resource.github));
+  if (resource.documentation) links.append(externalLink("Docs", resource.documentation));
+  if (hasProvenance(resource)) links.append(badge("provenance", "provenance-badge"));
   if (resource.api) links.append(badge("API", "api-badge"));
   if (resource.license) links.append(badge(resource.license, "license-badge"));
 
-  card.append(top, description, metadata, links);
+  card.append(top, description, metadata);
+  if (facts.childElementCount) card.append(facts);
+  if (links.childElementCount) card.append(links);
   return card;
 }
 
@@ -139,23 +206,26 @@ function frequency(field, resources = state.resources) {
     const values = field === "type" ? [resource.type] : arr(resource[field]);
     for (const value of values.filter(Boolean)) counts.set(value, (counts.get(value) || 0) + 1);
   }
-  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])));
 }
 
 function renderFacetBars(resources) {
   const groups = [
+    ["Entities", "entities"],
+    ["Methods", "methods"],
     ["Tasks", "tasks"],
     ["Modalities", "modalities"],
     ["Types", "type"],
   ];
   els.bars.replaceChildren();
   for (const [label, field] of groups) {
+    const top = frequency(field, resources).slice(0, 5);
+    if (!top.length) continue;
     const section = document.createElement("section");
     section.className = "bar-group";
     const heading = document.createElement("h3");
     heading.textContent = label;
     section.append(heading);
-    const top = frequency(field, resources).slice(0, 5);
     const max = Math.max(1, ...top.map(([, count]) => count));
     for (const [name, count] of top) {
       const row = document.createElement("div");
@@ -171,13 +241,17 @@ function renderFacetBars(resources) {
 }
 
 function renderActiveFilters() {
-  const values = [state.type, state.task, state.modality, state.organism, state.tag].filter(Boolean);
+  const values = [
+    state.type, state.task, state.modality, state.organism, state.tag,
+    state.entity, state.method, state.organization, state.year, state.maintenance,
+  ].filter(Boolean);
   els.active.replaceChildren();
-  if (!state.query && !values.length) return;
+  if (!state.query && !values.length && !state.enrichedOnly) return;
   const label = document.createElement("span");
   label.textContent = "Active:";
   els.active.append(label);
   if (state.query) els.active.append(badge(`search: ${state.query}`));
+  if (state.enrichedOnly) els.active.append(badge("enriched only", "enriched-badge"));
   values.forEach(value => els.active.append(badge(value)));
 }
 
@@ -195,20 +269,50 @@ function render() {
   renderFacetBars(resources);
 }
 
+function bindSelect(element, key) {
+  if (!element) return;
+  element.addEventListener("change", event => { state[key] = event.target.value; render(); });
+}
+
 function bind() {
   els.search.addEventListener("input", event => { state.query = event.target.value; render(); });
-  els.type.addEventListener("change", event => { state.type = event.target.value; render(); });
-  els.task.addEventListener("change", event => { state.task = event.target.value; render(); });
-  els.modality.addEventListener("change", event => { state.modality = event.target.value; render(); });
-  els.organism.addEventListener("change", event => { state.organism = event.target.value; render(); });
-  els.tag.addEventListener("change", event => { state.tag = event.target.value; render(); });
-  els.sort.addEventListener("change", event => { state.sort = event.target.value; render(); });
+  bindSelect(els.type, "type");
+  bindSelect(els.task, "task");
+  bindSelect(els.modality, "modality");
+  bindSelect(els.organism, "organism");
+  bindSelect(els.tag, "tag");
+  bindSelect(els.entity, "entity");
+  bindSelect(els.method, "method");
+  bindSelect(els.organization, "organization");
+  bindSelect(els.year, "year");
+  bindSelect(els.maintenance, "maintenance");
+  bindSelect(els.sort, "sort");
+  els.enrichedOnly.addEventListener("change", event => { state.enrichedOnly = event.target.checked; render(); });
   els.clear.addEventListener("click", () => {
-    Object.assign(state, {query: "", type: "", task: "", modality: "", organism: "", tag: ""});
+    Object.assign(state, {
+      query: "", type: "", task: "", modality: "", organism: "", tag: "",
+      entity: "", method: "", organization: "", year: "", maintenance: "", enrichedOnly: false,
+    });
     els.search.value = "";
-    [els.type, els.task, els.modality, els.organism, els.tag].forEach(select => { select.value = ""; });
+    [
+      els.type, els.task, els.modality, els.organism, els.tag, els.entity,
+      els.method, els.organization, els.year, els.maintenance,
+    ].forEach(select => { if (select) select.value = ""; });
+    els.enrichedOnly.checked = false;
     render();
   });
+}
+
+function renderSummary() {
+  const enriched = state.resources.filter(isEnriched);
+  const provenance = enriched.filter(hasProvenance);
+  const coverage = state.resources.length ? (enriched.length / state.resources.length) * 100 : 0;
+  els.statResources.textContent = state.resources.length.toLocaleString();
+  els.statEnriched.textContent = enriched.length.toLocaleString();
+  els.statCoverage.textContent = `${coverage.toFixed(1)}%`;
+  els.statEntities.textContent = collect("entities").length.toLocaleString();
+  els.statMethods.textContent = collect("methods").length.toLocaleString();
+  els.statProvenance.textContent = enriched.length ? `${Math.round((provenance.length / enriched.length) * 100)}%` : "0%";
 }
 
 async function init() {
@@ -221,10 +325,12 @@ async function init() {
     populate(els.modality, collect("modalities"));
     populate(els.organism, collect("organism"));
     populate(els.tag, collect("tags"));
-    els.statResources.textContent = state.resources.length.toLocaleString();
-    els.statTasks.textContent = collect("tasks").length.toLocaleString();
-    els.statModalities.textContent = collect("modalities").length.toLocaleString();
-    els.statTags.textContent = collect("tags").length.toLocaleString();
+    populate(els.entity, collect("entities"));
+    populate(els.method, collect("methods"));
+    populate(els.organization, collect("organizations"));
+    populate(els.year, collectScalar("year").sort((a, b) => Number(b) - Number(a)));
+    populate(els.maintenance, collectScalar("maintenance_status"));
+    renderSummary();
     bind();
     render();
   } catch (error) {


### PR DESCRIPTION
## Summary

Makes the AI4Bio landscape UI consume and expose the enrichment metadata now present in the generated resource registry.

### New exploration facets
- biological entity
- method
- publication year
- organization
- maintenance status
- enriched-only toggle

### Resource cards
- visually mark enriched records
- show entity and method badges
- show year, organization, maintenance status, and last-checked metadata when present
- surface Paper, GitHub, and Docs links
- mark records with provenance metadata

### Landscape summary
- total resources
- enriched resource count
- enrichment coverage percentage
- unique entities
- unique methods
- percentage of enriched records with provenance

### Behavior
Missing enrichment fields remain absent/unknown rather than inferred. Existing type/task/modality/organism/tag filters remain available for backward compatibility.

### Provenance
Implementation prepared with assistance from OpenAI GPT-5.6 Sol.