### PR TITLE
feat: expand provenance-backed foundation model enrichment

### DIFF
--- a/.github/workflows/ai4bio-schema-check.yml
+++ b/.github/workflows/ai4bio-schema-check.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - data/resources.yml
       - data/enrichment.yml
+      - 'data/enrichment.*.yml'
       - data/vocabulary.yml
       - docs/data/resource.schema.json
+      - scripts/enrichment_fragments.py
       - scripts/validate_resources.py
       - scripts/build_resources_v2.py
   push:
@@ -14,8 +16,10 @@ on:
     paths:
       - data/resources.yml
       - data/enrichment.yml
+      - 'data/enrichment.*.yml'
       - data/vocabulary.yml
       - docs/data/resource.schema.json
+      - scripts/enrichment_fragments.py
       - scripts/validate_resources.py
       - scripts/build_resources_v2.py
 

--- a/.github/workflows/sync_resources.yml
+++ b/.github/workflows/sync_resources.yml
@@ -8,6 +8,7 @@ on:
       - README.md
       - data/resources.yml
       - data/enrichment.yml
+      - 'data/enrichment.*.yml'
       - scripts/*.py
       - scripts/**/*.py
 

--- a/data/enrichment.foundation-models-v2.yml
+++ b/data/enrichment.foundation-models-v2.yml
@@ -1,0 +1,60 @@
+# Provenance-backed foundation model enrichment batch 2.
+resources:
+  nicheformer:
+    entities: [cell, gene, tissue]
+    methods: [self-supervised-learning, transformer]
+    modalities: [single-cell-rna-seq, spatial-transcriptomics, transcriptomics]
+    tasks: [foundation-model-pretraining, representation-learning]
+    year: 2024
+    github: https://github.com/theislab/nicheformer
+    paper: https://doi.org/10.1101/2024.04.15.589472
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/theislab/nicheformer
+      - https://doi.org/10.1101/2024.04.15.589472
+
+  genept:
+    entities: [cell, gene]
+    methods: [language-model]
+    modalities: [single-cell-rna-seq, transcriptomics]
+    tasks: [batch-correction, classification, representation-learning]
+    year: 2023
+    github: https://github.com/yiqunchen/GenePT
+    paper: https://www.biorxiv.org/content/10.1101/2023.10.16.562533v2
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/yiqunchen/GenePT
+      - https://www.biorxiv.org/content/10.1101/2023.10.16.562533v2
+
+  scgpt_spatial:
+    entities: [cell, gene, tissue]
+    methods: [generative-model, self-supervised-learning, transformer]
+    modalities: [multi-omics, single-cell-rna-seq, spatial-transcriptomics]
+    tasks: [foundation-model-pretraining, imputation, representation-learning]
+    year: 2025
+    github: https://github.com/bowang-lab/scGPT-spatial
+    paper: https://www.biorxiv.org/content/10.1101/2025.02.05.636714v1
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/bowang-lab/scGPT-spatial
+      - https://www.biorxiv.org/content/10.1101/2025.02.05.636714v1
+
+  scprint:
+    entities: [cell, gene]
+    methods: [self-supervised-learning, transformer]
+    modalities: [single-cell-rna-seq, transcriptomics]
+    tasks:
+      - batch-correction
+      - cell-type-annotation
+      - foundation-model-pretraining
+      - gene-regulatory-network-inference
+      - imputation
+      - representation-learning
+    year: 2025
+    github: https://github.com/cantinilab/scPRINT
+    documentation: https://www.jkobject.com/scPRINT/
+    paper: https://www.nature.com/articles/s41467-025-58699-1
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/cantinilab/scPRINT
+      - https://www.nature.com/articles/s41467-025-58699-1

--- a/scripts/build_resources_v2.py
+++ b/scripts/build_resources_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build enriched AI4Bio artifacts from data/resources.yml + data/enrichment.yml."""
+"""Build enriched AI4Bio artifacts from base resources and modular enrichment."""
 
 from __future__ import annotations
 
@@ -18,11 +18,12 @@ except ImportError:
     print("ERROR: PyYAML is not installed. Run: pip install pyyaml", file=sys.stderr)
     sys.exit(1)
 
+from enrichment_fragments import load_enrichment
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = REPO_ROOT / "data"
 DOCS_DATA_DIR = REPO_ROOT / "docs" / "data"
 BASE_FILE = DATA_DIR / "resources.yml"
-ENRICHMENT_FILE = DATA_DIR / "enrichment.yml"
 JSON_OUTPUT = DATA_DIR / "resources.json"
 CSV_OUTPUT = DATA_DIR / "resources.csv"
 DOCS_JSON_OUTPUT = DOCS_DATA_DIR / "resources.json"
@@ -52,11 +53,9 @@ def load_yaml(path: Path) -> dict[str, Any]:
 
 def merge_entries() -> list[dict[str, Any]]:
     base = load_yaml(BASE_FILE).get("resources", [])
-    overlay = load_yaml(ENRICHMENT_FILE).get("resources", {})
+    overlay = load_enrichment(DATA_DIR, load_yaml)
     if not isinstance(base, list):
         raise ValueError("data/resources.yml 'resources' must be a list")
-    if not isinstance(overlay, dict):
-        raise ValueError("data/enrichment.yml 'resources' must be a mapping keyed by resource id")
 
     entries: list[dict[str, Any]] = []
     known_ids = {entry.get("id") for entry in base if isinstance(entry, dict)}
@@ -78,9 +77,6 @@ def merge_entries() -> list[dict[str, Any]]:
             )
         entry.update(extra)
 
-        # Preserve the legacy artifact shape when no enrichment is present.
-        # Base list fields have always been normalized to arrays, but v2-only
-        # list fields are normalized only when explicitly supplied.
         for field in BASE_LIST_FIELDS:
             value = entry.get(field)
             if value is None:
@@ -105,7 +101,6 @@ def merge_entries() -> list[dict[str, Any]]:
 
 
 def csv_columns(entries: list[dict[str, Any]]) -> list[str]:
-    """Return legacy columns unless at least one v2 enrichment field is present."""
     has_enrichment = any(
         any(field in entry for field in ENRICHMENT_CSV_COLUMNS)
         for entry in entries
@@ -142,10 +137,6 @@ def running_in_pr_ci() -> bool:
 
 
 def write_outputs(entries: list[dict[str, Any]]) -> None:
-    # Pull-request CI is validation-only. Build into a temporary directory so
-    # the workflow can verify that generation succeeds without requiring every
-    # enrichment PR to commit large derived artifacts. On main/push, outputs
-    # are materialized normally and Sync Resources commits any resulting diff.
     if running_in_pr_ci():
         with tempfile.TemporaryDirectory(prefix="ai4bio-build-") as tmp:
             tmp_dir = Path(tmp)

--- a/scripts/enrichment_fragments.py
+++ b/scripts/enrichment_fragments.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Load modular AI4Bio enrichment YAML fragments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+def enrichment_files(data_dir: Path) -> list[Path]:
+    primary = data_dir / "enrichment.yml"
+    fragments = sorted(data_dir.glob("enrichment.*.yml"))
+    return [primary, *fragments]
+
+
+def load_enrichment(
+    data_dir: Path,
+    load_yaml: Callable[[Path], dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge enrichment fragments and reject duplicate resource IDs."""
+    merged: dict[str, Any] = {}
+    owners: dict[str, str] = {}
+    for path in enrichment_files(data_dir):
+        resources = load_yaml(path).get("resources", {})
+        if not isinstance(resources, dict):
+            raise ValueError(f"{path}: 'resources' must be a mapping keyed by resource id")
+        for resource_id, fields in resources.items():
+            if resource_id in merged:
+                raise ValueError(
+                    f"duplicate enrichment id {resource_id!r} in {owners[resource_id]} and {path.name}"
+                )
+            merged[resource_id] = fields
+            owners[resource_id] = path.name
+    return merged

--- a/scripts/validate_resources.py
+++ b/scripts/validate_resources.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate AI4Bio resource YAML and enrichment metadata without extra dependencies."""
+"""Validate AI4Bio resource YAML and modular enrichment metadata."""
 
 from __future__ import annotations
 
@@ -16,10 +16,12 @@ except ImportError:
     print("ERROR: PyYAML is not installed. Run: pip install pyyaml", file=sys.stderr)
     sys.exit(1)
 
+from enrichment_fragments import load_enrichment
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-BASE_FILE = REPO_ROOT / "data" / "resources.yml"
-ENRICHMENT_FILE = REPO_ROOT / "data" / "enrichment.yml"
-VOCABULARY_FILE = REPO_ROOT / "data" / "vocabulary.yml"
+DATA_DIR = REPO_ROOT / "data"
+BASE_FILE = DATA_DIR / "resources.yml"
+VOCABULARY_FILE = DATA_DIR / "vocabulary.yml"
 
 REQUIRED_FIELDS = ("id", "name", "type", "url", "description")
 LIST_FIELDS = (
@@ -63,7 +65,6 @@ def validate_date(value: Any) -> bool:
 
 
 def load_vocabulary() -> tuple[dict[str, set[str]], list[str]]:
-    """Load and validate canonical terms used by new enrichment metadata."""
     errors: list[str] = []
     raw = load_yaml(VOCABULARY_FILE)
     controlled = raw.get("controlled_fields")
@@ -103,7 +104,6 @@ def validate_enrichment_vocabulary(
     fields: dict[str, Any],
     vocabulary: dict[str, set[str]],
 ) -> list[str]:
-    """Require canonical terms only for controlled fields added by enrichment."""
     errors: list[str] = []
     for field in CONTROLLED_FIELDS:
         if field not in fields:
@@ -124,14 +124,15 @@ def validate_enrichment_vocabulary(
 def merge_resources() -> tuple[list[dict[str, Any]], list[str]]:
     errors: list[str] = []
     base = load_yaml(BASE_FILE).get("resources", [])
-    overlay = load_yaml(ENRICHMENT_FILE).get("resources", {})
+    try:
+        overlay = load_enrichment(DATA_DIR, load_yaml)
+    except ValueError as exc:
+        return [], [str(exc)]
     vocabulary, vocabulary_errors = load_vocabulary()
     errors.extend(vocabulary_errors)
 
     if not isinstance(base, list):
         return [], errors + ["data/resources.yml: 'resources' must be a list"]
-    if not isinstance(overlay, dict):
-        return [], errors + ["data/enrichment.yml: 'resources' must be a mapping keyed by resource id"]
 
     by_id: dict[str, dict[str, Any]] = {}
     for index, raw in enumerate(base, 1):
@@ -185,7 +186,8 @@ def validate_entry(entry: dict[str, Any]) -> list[str]:
             errors.append(f"[{rid}] '{field}' must be an http(s) URL")
     if entry.get("github") and not str(entry["github"]).startswith("https://github.com/"):
         errors.append(f"[{rid}] 'github' must be a github.com URL")
-    for value in entry.get("metadata_sources", []) if isinstance(entry.get("metadata_sources", []), list) else []:
+    sources = entry.get("metadata_sources", [])
+    for value in sources if isinstance(sources, list) else []:
         if not valid_http_url(value):
             errors.append(f"[{rid}] metadata source must be an http(s) URL: {value}")
     for field in DATE_FIELDS:
@@ -212,7 +214,7 @@ def main() -> None:
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         sys.exit(1)
-    print(f"Validated {len(entries)} resources, enrichment metadata, and controlled vocabulary.")
+    print(f"Validated {len(entries)} resources, enrichment fragments, and controlled vocabulary.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a second provenance-backed foundation-model enrichment batch and makes enrichment scalable by allowing modular `data/enrichment.*.yml` fragments.

### Models added
- Nicheformer
- GenePT
- scGPT-spatial
- scPRINT

### Pipeline
- adds `scripts/enrichment_fragments.py`
- merges `data/enrichment.yml` with sorted `data/enrichment.*.yml` fragments
- rejects duplicate resource IDs across fragments
- updates validator and builder to use the same merged overlay
- updates schema/sync workflow path filters so fragment-only changes are validated and materialized

### Curation policy
Only source-verifiable metadata is included. Unknown organization/access/maintenance claims remain omitted.

### Provenance
Curation and implementation prepared with assistance from OpenAI GPT-5.6 Sol.