### PR TITLE
feat: apply protein and drug enrichment to main

### DIFF
--- a/data/enrichment.protein-drug-v1.yml
+++ b/data/enrichment.protein-drug-v1.yml
@@ -1,0 +1,49 @@
+# Provenance-backed protein and drug-discovery enrichment batch.
+resources:
+  esmfold:
+    entities: [protein]
+    methods: [language-model, transformer]
+    modalities: [molecular-structure, protein-sequence]
+    tasks: [representation-learning, structure-prediction]
+    year: 2023
+    github: https://github.com/facebookresearch/esm
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/facebookresearch/esm
+
+  proteinmpnn:
+    entities: [protein]
+    methods: [graph-neural-network, message-passing-neural-network]
+    modalities: [molecular-structure, protein-sequence]
+    tasks: [protein-sequence-design]
+    year: 2022
+    github: https://github.com/dauparas/ProteinMPNN
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/dauparas/ProteinMPNN
+
+  diffdock:
+    entities: [molecule, protein]
+    methods: [diffusion, geometric-deep-learning]
+    modalities: [molecular-structure]
+    tasks: [docking]
+    year: 2023
+    github: https://github.com/gcorso/DiffDock
+    paper: https://openreview.net/forum?id=kKF8_K-mBbS
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/gcorso/DiffDock
+      - https://openreview.net/forum?id=kKF8_K-mBbS
+
+  uni_mol:
+    entities: [molecule, protein]
+    methods: [self-supervised-learning, transformer]
+    modalities: [chemical-structure, molecular-structure]
+    tasks: [docking, representation-learning]
+    year: 2023
+    github: https://github.com/deepmodeling/Uni-Mol
+    paper: https://openreview.net/forum?id=6K2RM6wVqKu
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/deepmodeling/Uni-Mol
+      - https://openreview.net/forum?id=6K2RM6wVqKu

--- a/data/vocabulary.yml
+++ b/data/vocabulary.yml
@@ -84,6 +84,7 @@ controlled_fields:
     - molecular-generation
     - perturbation-prediction
     - protein-function-prediction
+    - protein-sequence-design
     - regression
     - representation-learning
     - structure-prediction


### PR DESCRIPTION
## Summary

Re-applies the protein and drug-discovery enrichment from #105 directly against `main`, because #105 was merged into the feature branch used by #102 rather than into `main`.

### Models added
- ESMFold
- ProteinMPNN
- DiffDock
- Uni-Mol

### Metadata
Adds provenance-backed entities, methods, modalities, tasks, year, GitHub links, primary paper links where directly verified, `last_checked`, and metadata sources.

### Vocabulary
Adds `protein-sequence-design` as a canonical task for ProteinMPNN rather than misclassifying sequence design as structure prediction.

### Expected landscape effect
After merge and a successful `Sync Resources` run, these four records should become visible to the landscape enrichment layer in addition to the #102 foundation-model batch.

### Provenance
Curation and implementation prepared with assistance from OpenAI GPT-5.6 Sol.