### PR TITLE
feat: expand biomedical benchmark and single-cell enrichment

### DIFF
--- a/data/enrichment.benchmark-v2.yml
+++ b/data/enrichment.benchmark-v2.yml
@@ -1,0 +1,43 @@
+# Provenance-backed single-cell and biomedical benchmark enrichment batch.
+resources:
+  scmulan:
+    entities: [cell, gene]
+    methods: [language-model, transformer]
+    modalities: [epigenomics, multi-omics, proteomics, single-cell-rna-seq, transcriptomics]
+    tasks: [foundation-model-pretraining, representation-learning]
+    github: https://github.com/SuperBianC/scMulan
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/SuperBianC/scMulan
+
+  proteingym:
+    entities: [protein]
+    modalities: [protein-sequence]
+    tasks: [regression]
+    github: https://github.com/OATML-Markslab/ProteinGym
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://github.com/OATML-Markslab/ProteinGym
+
+  lincs_l1000:
+    entities: [cell, compound, gene]
+    modalities: [transcriptomics]
+    tasks: [perturbation-prediction]
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://lincsproject.org/LINCS/tools/workflows/find-the-best-place-to-obtain-the-lincs-l1000-data
+
+  prism:
+    entities: [cell, drug]
+    tasks: [drug-response-prediction]
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://depmap.org/portal/prism/
+
+  pharmgkb:
+    entities: [drug, gene, phenotype, variant]
+    modalities: [clinical, genomics]
+    tasks: [drug-response-prediction]
+    last_checked: 2026-08-08
+    metadata_sources:
+      - https://www.pharmgkb.org/


### PR DESCRIPTION
## Summary

Adds a provenance-backed single-cell and biomedical benchmark enrichment batch to increase AI4Bio landscape coverage.

### Resources
- scMulan
- ProteinGym
- LINCS L1000
- PRISM
- PharmGKB

### Metadata
Adds canonical entities, methods/modalities/tasks where directly supported, GitHub links when applicable, `last_checked`, and metadata sources.

### Curation policy
Only source-verifiable metadata is included. Ambiguous organization/access/maintenance claims remain omitted.

### Expected coverage effect
Adds 5 newly enriched resources. Together with #107 and #108, the planned total becomes 30 enriched resources, or roughly 10.2% of the current 293-resource registry after generated artifacts sync.

### Provenance
Curation and implementation prepared with assistance from OpenAI GPT-5.6 Sol.